### PR TITLE
Fix array serialization

### DIFF
--- a/src/Presto/Core/Types/Language/Storage.purs
+++ b/src/Presto/Core/Types/Language/Storage.purs
@@ -8,7 +8,7 @@ module Presto.Core.Types.Language.Storage
 import Prelude
 
 import Control.Monad.Except (runExcept)
-import Data.Either (either)
+import Data.Either (hush)
 import Data.Foreign.Class (class Decode)
 import Data.Foreign.Generic (decodeJSON, encodeJSON)
 import Data.Maybe (Maybe(..))
@@ -25,7 +25,7 @@ instance stringSerializable :: Serializable String where
   deserialize = Just
 
 primDeserialize :: forall a. Decode a => String -> Maybe a
-primDeserialize = decodeJSON >>> runExcept >>> either (const Nothing) Just
+primDeserialize = decodeJSON >>> runExcept >>> hush
 
 instance booleanSerializable :: Serializable Boolean where
   serialize = encodeJSON


### PR DESCRIPTION
The previous array serialization instance I wrote wasn't deserializing correctly. Fixed that.

Also, took a different approach. Instead of mapping `serialize` over the Array (which gives you an array of Strings) now it appends `[`, `]` and `,` around the items. That way, the output of serializing an array is the same as the output of `JSON.stringify`ing an array, which could be useful if you're serializing outside of presto but deserializing inside presto (like in Local Storage).

I'm not sure if the approach I took to deserializing was the best. Couldn't find another way without requiring a `Decode` or `Encode` instance for the Type or having to pattern match